### PR TITLE
fix ros buildfarm ci

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
 
   <build_depend>eigen</build_depend>
   <build_depend>jrl_cmakemodules</build_depend>
+  <build_depend>tf2_eigen</build_depend>
 
   <depend>builtin_interfaces</depend>
   <depend>std_msgs</depend>


### PR DESCRIPTION
`build_export_depend` is enough for ros industrial ci: https://github.com/loco-3d/linear-feedback-controller-msgs/actions/workflows/ci_ros2.yml but not ros buildfarm:
https://build.ros2.org/job/Rdev__linear_feedback_controller_msgs__ubuntu_noble_amd64

```
22:12:28 CMake Error at CMakeLists.txt:31 (find_package):
22:12:28   By not providing "Findtf2_eigen.cmake" in CMAKE_MODULE_PATH this project
22:12:28   has asked CMake to find a package configuration file provided by
22:12:28   "tf2_eigen", but CMake did not find one.
22:12:28
22:12:28   Could not find a package configuration file provided by "tf2_eigen" with
22:12:28   any of the following names:
22:12:28
22:12:28     tf2_eigenConfig.cmake
22:12:28     tf2_eigen-config.cmake
22:12:28
22:12:28   Add the installation prefix of "tf2_eigen" to CMAKE_PREFIX_PATH or set
22:12:28   "tf2_eigen_DIR" to a directory containing one of the above files.  If
22:12:28   "tf2_eigen" provides a separate development package or SDK, be sure it has
22:12:28   been installed.
```